### PR TITLE
docs(snappy-ui): refactor docs to use Tabs for code and preview sections

### DIFF
--- a/apps/snappyui/components/ui/snappy-footer.tsx
+++ b/apps/snappyui/components/ui/snappy-footer.tsx
@@ -40,15 +40,14 @@ export default function Footer({
 }: FooterProps) {
   // Container styles based on variant
   const containerStyles = {
-    simple: "bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800",
-    detailed: "bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800",
     minimal: "bg-transparent",
     centered: "bg-white dark:bg-gray-900 text-center border-t border-gray-200 dark:border-gray-800",
-    modern: "bg-white dark:bg-zinc-900 border-t border-zinc-200 dark:border-zinc-800",
-    classic: "bg-zinc-100 dark:bg-zinc-800 border-t border-zinc-300 dark:border-zinc-700",
     elegant: "bg-gradient-to-r from-white to-zinc-100 dark:from-zinc-900 dark:to-zinc-800",
-    dark: "bg-black text-white border-t border-zinc-700",
-
+    simple: "bg-gray-100 dark:bg-gray-800",
+    detailed: "bg-gray-200 dark:bg-gray-700",
+    modern: "bg-gray-50 dark:bg-gray-900",
+    classic: "bg-gray-300 dark:bg-gray-600",
+    dark: "bg-black text-white",
   };
 
   // Size styles for padding and spacing
@@ -60,179 +59,36 @@ export default function Footer({
 
   // Link styles based on variant
   const linkStyles = {
-    simple:
-      "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 no-underline",
-    detailed:
-      "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 no-underline",
     minimal:
       "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 no-underline",
     centered:
       "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 no-underline",
-    modern:
-      "text-zinc-600 hover:text-black dark:text-zinc-300 dark:hover:text-white no-underline",
-    classic:
-      "text-zinc-700 hover:text-black dark:text-zinc-200 dark:hover:text-white no-underline",
     elegant:
       "text-zinc-800 hover:text-zinc-900 dark:text-zinc-200 dark:hover:text-white no-underline",
-    dark:
-      "text-zinc-300 hover:text-white no-underline",
   };
 
   // Column title styles based on variant
   const titleStyles = {
-    simple: "font-semibold text-gray-900 dark:text-gray-100 mb-4",
-    detailed:
-      "font-semibold text-gray-900 dark:text-gray-100 mb-4 uppercase tracking-wider text-sm",
     minimal: "font-medium text-gray-900 dark:text-gray-100 mb-2",
-    centered:
-      "font-semibold text-gray-900 dark:text-gray-100 mb-4 uppercase tracking-wider text-sm",
-    modern: "text-sm text-zinc-500 mt-6 dark:text-zinc-400",
-    classic: "text-sm text-zinc-600 mt-6 dark:text-zinc-300",
+    centered: "font-semibold text-gray-900 dark:text-gray-100 mb-4 uppercase tracking-wider text-sm",
     elegant: "text-sm italic text-zinc-700 mt-6 dark:text-zinc-300",
-    dark: "text-sm text-zinc-400 mt-8 border-t border-zinc-700 pt-6",
   };
 
   // Social links container styles
   const socialContainerStyles = {
-    simple: "flex space-x-6 mt-4",
-    detailed: "flex space-x-4",
     minimal: "flex space-x-4",
     centered: "flex justify-center space-x-6 mt-6",
-    dark: "flex space-x-4",
   };
 
   // Copyright styles
   const copyrightStyles = {
-    simple: "text-gray-500 text-sm mt-4 dark:text-gray-400",
-    detailed:
-      "text-gray-500 text-sm pt-8 mt-8 border-t border-gray-200 dark:border-gray-800 dark:text-gray-400",
     minimal: "text-gray-500 text-sm mt-4 dark:text-gray-400",
     centered: "text-gray-500 text-sm mt-6 dark:text-gray-400",
-    dark: "text-gray-400 text-sm pt-8 mt-8 border-t border-gray-800",
   };
 
   // Render different layouts based on variant
   const renderContent = () => {
     switch (variant) {
-      case "simple":
-        return (
-          <div className="container mx-auto px-4">
-            <div className="flex flex-col md:flex-row justify-between">
-              <div className="mb-6 md:mb-0">
-                {logo && <div className="mb-4">{logo}</div>}
-                <p className={copyrightStyles[variant]}>{copyright}</p>
-                {socialLinks.length > 0 && (
-                  <div className={socialContainerStyles[variant]}>
-                    {socialLinks.map((link, index) => (
-                      <a
-                        key={index}
-                        href={link.href}
-                        className={linkStyles[variant]}
-                        target={link.external ? "_blank" : undefined}
-                        rel={link.external ? "noopener noreferrer" : undefined}
-                      >
-                        {link.label}
-                      </a>
-                    ))}
-                  </div>
-                )}
-              </div>
-              {columns.length > 0 && (
-                <div className="grid grid-cols-2 sm:grid-cols-3 gap-8">
-                  {columns.map((column, index) => (
-                    <div key={index}>
-                      {column.title && (
-                        <h3 className={titleStyles[variant]}>{column.title}</h3>
-                      )}
-                      <ul className="space-y-2">
-                        {column.links.map((link, linkIndex) => (
-                          <li key={linkIndex}>
-                            <a
-                              href={link.href}
-                              className={linkStyles[variant]}
-                              target={link.external ? "_blank" : undefined}
-                              rel={
-                                link.external
-                                  ? "noopener noreferrer"
-                                  : undefined
-                              }
-                            >
-                              {link.label}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-            {bottomText && (
-              <div className="mt-8 pt-8 border-t border-gray-200 dark:border-gray-800">
-                <p className="text-gray-500 text-sm dark:text-gray-400">
-                  {bottomText}
-                </p>
-              </div>
-            )}
-          </div>
-        );
-
-      case "detailed":
-        return (
-          <div className="container mx-auto px-4">
-            <div className="grid grid-cols-1 md:grid-cols-4 lg:grid-cols-6 gap-8">
-              <div className="md:col-span-1 lg:col-span-2">
-                {logo && <div className="mb-4">{logo}</div>}
-                {socialLinks.length > 0 && (
-                  <div className={socialContainerStyles[variant]}>
-                    {socialLinks.map((link, index) => (
-                      <a
-                        key={index}
-                        href={link.href}
-                        className={linkStyles[variant]}
-                        target={link.external ? "_blank" : undefined}
-                        rel={link.external ? "noopener noreferrer" : undefined}
-                      >
-                        {link.label}
-                      </a>
-                    ))}
-                  </div>
-                )}
-              </div>
-              {columns.length > 0
-                && columns.map((column, index) => (
-                  <div key={index}>
-                    {column.title && (
-                      <h3 className={titleStyles[variant]}>{column.title}</h3>
-                    )}
-                    <ul className="space-y-2">
-                      {column.links.map((link, linkIndex) => (
-                        <li key={linkIndex}>
-                          <a
-                            href={link.href}
-                            className={linkStyles[variant]}
-                            target={link.external ? "_blank" : undefined}
-                            rel={
-                              link.external ? "noopener noreferrer" : undefined
-                            }
-                          >
-                            {link.label}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-            </div>
-            <div className={copyrightStyles[variant]}>
-              <div className="flex flex-col md:flex-row md:justify-between md:items-center">
-                <p>{copyright}</p>
-                {bottomText && <p className="mt-2 md:mt-0">{bottomText}</p>}
-              </div>
-            </div>
-          </div>
-        );
-
       case "minimal":
         return (
           <div className="container mx-auto px-4">
@@ -317,122 +173,6 @@ export default function Footer({
           </div>
         );
 
-      case "dark":
-        return (
-          <div className="container mx-auto px-4">
-            <div className="grid grid-cols-1 md:grid-cols-4 lg:grid-cols-6 gap-8">
-              <div className="md:col-span-1 lg:col-span-2">
-                {logo && <div className="mb-4">{logo}</div>}
-                <p className="text-zinc-400 mb-4">
-                  {bottomText
-                    || "Building amazing digital experiences with cutting-edge technology."}
-                </p>
-                {socialLinks.length > 0 && (
-                  <div className="flex space-x-4 mt-4">
-                    {socialLinks.map((link, index) => (
-                      <a
-                        key={index}
-                        href={link.href}
-                        className="text-zinc-300 hover:text-white transition-colors"
-                        target={link.external ? "_blank" : undefined}
-                        rel={link.external ? "noopener noreferrer" : undefined}
-                      >
-                        {link.label}
-                      </a>
-                    ))}
-                  </div>
-                )}
-              </div>
-              {columns.length > 0
-                && columns.map((column, index) => (
-                  <div key={index}>
-                    {column.title && (
-                      <h3 className="uppercase font-semibold text-white mb-4">
-                        {column.title}
-                      </h3>
-                    )}
-                    <ul className="space-y-2">
-                      {column.links.map((link, linkIndex) => (
-                        <li key={linkIndex}>
-                          <a
-                            href={link.href}
-                            className="text-zinc-300 hover:text-white transition-colors"
-                            target={link.external ? "_blank" : undefined}
-                            rel={
-                              link.external ? "noopener noreferrer" : undefined
-                            }
-                          >
-                            {link.label}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-            </div>
-            <div className="text-zinc-400 text-sm pt-8 mt-8 border-t border-zinc-700">
-              <p>{copyright}</p>
-            </div>
-          </div>
-        );
-
-      case "modern":
-        return (
-          <div className="container mx-auto px-4">
-            <div className="flex flex-col md:flex-row justify-between items-start gap-8">
-              <div className="md:w-1/3">
-                {logo && <div className="mb-4">{logo}</div>}
-                {socialLinks.length > 0 && (
-                  <div className="flex space-x-4 mt-4">
-                    {socialLinks.map((link, index) => (
-                      <a
-                        key={index}
-                        href={link.href}
-                        className={linkStyles[variant]}
-                        target={link.external ? "_blank" : undefined}
-                        rel={link.external ? "noopener noreferrer" : undefined}
-                      >
-                        {link.label}
-                      </a>
-                    ))}
-                  </div>
-                )}
-              </div>
-              {columns.length > 0 && (
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-8 md:w-2/3">
-                  {columns.map((column, index) => (
-                    <div key={index}>
-                      {column.title && (
-                        <h3 className={titleStyles[variant]}>{column.title}</h3>
-                      )}
-                      <ul className="space-y-2">
-                        {column.links.map((link, linkIndex) => (
-                          <li key={linkIndex}>
-                            <a
-                              href={link.href}
-                              className={linkStyles[variant]}
-                              target={link.external ? "_blank" : undefined}
-                              rel={
-                                link.external ? "noopener noreferrer" : undefined
-                              }
-                            >
-                              {link.label}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-            <div className="text-white text-sm pt-8 mt-8 border-t border-gray-800">
-              <p>{copyright}</p>
-              {bottomText && <p className="mt-2">{bottomText}</p>}
-            </div>
-          </div>
-        );
-
       case "elegant":
         return (
           <div className="container mx-auto px-4">
@@ -473,63 +213,6 @@ export default function Footer({
             </div>
             <div className="text-gray-500 text-sm pt-8 mt-8 border-t border-gray-200 dark:border-gray-800 dark:text-gray-400">
               <p className="mt-0">{copyright}</p>
-              {bottomText && <p className="mt-2">{bottomText}</p>}
-            </div>
-          </div>
-        );
-
-      case "classic":
-        return (
-          <div className="container mx-auto px-4">
-            <div className="flex flex-col md:flex-row justify-between items-start gap-8">
-              <div className="mb-6 md:mb-0">
-                {logo && <div className="mb-4">{logo}</div>}
-                {socialLinks.length > 0 && (
-                  <div className="flex space-x-4 mt-2">
-                    {socialLinks.map((link, index) => (
-                      <a
-                        key={index}
-                        href={link.href}
-                        className={linkStyles[variant]}
-                        target={link.external ? "_blank" : undefined}
-                        rel={link.external ? "noopener noreferrer" : undefined}
-                      >
-                        {link.label}
-                      </a>
-                    ))}
-                  </div>
-                )}
-              </div>
-              {columns.length > 0 && (
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
-                  {columns.map((column, index) => (
-                    <div key={index}>
-                      {column.title && (
-                        <h3 className={titleStyles[variant]}>{column.title}</h3>
-                      )}
-                      <ul className="space-y-2">
-                        {column.links.map((link, linkIndex) => (
-                          <li key={linkIndex}>
-                            <a
-                              href={link.href}
-                              className={linkStyles[variant]}
-                              target={link.external ? "_blank" : undefined}
-                              rel={
-                                link.external ? "noopener noreferrer" : undefined
-                              }
-                            >
-                              {link.label}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-            <div className="text-gray-700 text-sm pt-8 mt-8 border-t border-gray-200">
-              <p>{copyright}</p>
               {bottomText && <p className="mt-2">{bottomText}</p>}
             </div>
           </div>

--- a/apps/snappyui/content/docs/components/snappybutton.mdx
+++ b/apps/snappyui/content/docs/components/snappybutton.mdx
@@ -8,257 +8,462 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 ---
 
-
-
 ## Basic Usage
-
-<div className="flex flex-col items-center justify-center mb-6 border border-zinc-800 rounded-lg py-5">
-  <div className="flex flex-col items-center gap-4">
-    <Button variant="primary" size="lg">Primary Button</Button>
-    <Button variant="success" size="default">Success Button</Button>
-    <Button variant="destructive" size="sm">Destructive Button</Button>
-  </div>
-</div>
-
-```tsx
-import Button from "@/components/ui/snappy-button";
-
-export default function ButtonExample() {
-  return (
-    <div className="flex flex-col items-center gap-4">
-      <Button variant="primary" size="lg">Primary Button</Button>
-      <Button variant="success" size="default">Success Button</Button>
-      <Button variant="destructive" size="sm">Destructive Button</Button>
-    </div>
-  );
-}
-```
-
----
-
-### Variants
 
 <Tabs
   items={[
-    "default",
-    "primary",
-    "success",
-    "destructive",
-    "outline",
-    "ghost",
-    "warning",
-    "gradient",
-    "moving-border",
+    "Preview",
+    "Code",
   ]}
 >
-  <Tab value="default">
-    <Button variant="default">Default Button</Button>
-  </Tab>
-  <Tab value="primary">
-    <Button variant="primary">Primary Button</Button>
-  </Tab>
-  <Tab value="success">
-    <Button variant="success">Success Button</Button>
-  </Tab>
-  <Tab value="destructive">
-    <Button variant="destructive">Destructive Button</Button>
-  </Tab>
-  <Tab value="outline">
-    <Button variant="outline">Outline Button</Button>
-  </Tab>
-  <Tab value="ghost">
-    <Button variant="ghost">Ghost Button</Button>
-  </Tab>
-  <Tab value="warning">
-    <Button variant="warning">Warning Button</Button>
-  </Tab>
-  <Tab value="gradient">
-    <Button variant="gradient">Gradient Button</Button>
-  </Tab>
-  <Tab value="moving-border">
-    <Button variant="moving-border">Moving Border</Button>
-  </Tab>
-</Tabs>
 
-```tsx
-<Button variant="default">Default Button</Button>
-<Button variant="primary">Primary Button</Button>
-<Button variant="success">Success Button</Button>
-<Button variant="destructive">Destructive Button</Button>
-<Button variant="outline">Outline Button</Button>
-<Button variant="ghost">Ghost Button</Button>
-<Button variant="warning">Warning Button</Button>
-<Button variant="gradient">Gradient Button</Button>
-<Button variant="moving-border">Moving Border</Button>
-```
+    <Tab value="Preview">
+
+      <Button variant="default">Default</Button>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+      <Button variant="default">Default</Button>
+      ```
+
+    </Tab>
+
+</Tabs>
 
 ---
 
-### Sizes
+## Variations
 
-<Tabs items={["sm", "default", "lg", "xl"]}>
-  <Tab value="sm">
-    <Button size="sm">Small Button</Button>
-  </Tab>
-  <Tab value="default">
-    <Button size="default">Default Button</Button>
-  </Tab>
-  <Tab value="lg">
-    <Button size="lg">Large Button</Button>
-  </Tab>
-  <Tab value="xl">
-    <Button size="xl">Extra Large Button</Button>
-  </Tab>
-</Tabs>
+### Primary
 
-```tsx
-<Button size="sm">Small Button</Button>
-<Button size="default">Default Button</Button>
-<Button size="lg">Large Button</Button>
-<Button size="xl">Extra Large Button</Button>
-```
-
----
-
-### MovingBorder Component
-
-The `MovingBorder` component can be used independently:
-
-```tsx
-import { MovingBorder } from "@/components/ui/snappy-button";
-
-export default function CustomMovingBorder() {
-  return (
-    <div className="relative h-40 w-40">
-      <MovingBorder duration={2000} rx="30%" ry="30%" borderColor="#22c55e">
-        <div className="h-20 w-20 opacity-80" 
-          style={{ background: "radial-gradient(#22c55e 40%, transparent 60%)" }} 
-        />
-      </MovingBorder>
-      <div className="relative flex h-full w-full items-center justify-center">
-        Your content here
-      </div>
-    </div>
-  );
-}
-```
-
-### Moving Border Animation
-
-The moving border variant creates a dynamic animated border effect.
-
-<div className="flex flex-col items-center justify-center mb-6 border border-zinc-800 rounded-lg py-5">
-  <div className="flex flex-wrap justify-center gap-4">
-    <Button 
-      variant="moving-border" 
-      borderColor="#0ea5e9"
-    >
-      Default Blue
-    </Button>
-    <Button 
-      variant="moving-border" 
-      borderColor="#22c55e"
-    >
-      Custom Green
-    </Button>
-    <Button 
-      variant="moving-border" 
-      borderColor="#ef4444"
-      duration={2000}
-    >
-      Faster Red
-    </Button>
-  </div>
-</div>
-
-```tsx
-<Button variant="moving-border" borderColor="#0ea5e9">
-  Default Blue
-</Button>
-
-<Button variant="moving-border" borderColor="#22c55e">
-  Custom Green
-</Button>
-
-<Button variant="moving-border" borderColor="#ef4444" duration={2000}>
-  Faster Red
-</Button>
-```
-
-You can also use a custom border style with Tailwind classes:
-
-```tsx
-<Button 
-  variant="moving-border" 
-  borderClassName="bg-gradient-to-r from-purple-500 to-pink-500"
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
 >
-  Gradient Border
-</Button>
-```
+
+    <Tab value="Preview">
+
+       <Button variant="primary">Primary</Button>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+      <Button variant="primary">Primary</Button>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Success
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <Button variant="success">Success</Button>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+      <Button variant="success">Success</Button>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Destructive
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <Button variant="destructive">Destructive</Button>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+      <Button variant="destructive">Destructive</Button>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Outline
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <Button variant="outline">Outline</Button>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+      <Button variant="outline">Outline</Button>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Ghost
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <Button variant="ghost">Ghost</Button>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+      <Button variant="ghost">Ghost</Button>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Warning
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <Button variant="warning">Warning</Button>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+      <Button variant="warning">Warning</Button>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Gradient
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <Button variant="gradient">Gradient</Button>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+      <Button variant="gradient">Gradient</Button>
+      ```
+
+    </Tab>
+
+</Tabs>
 
 ---
 
-### Custom Border Radius
+## Moving Border Component
 
-<Tabs items={["default", "rounded", "square", "pill"]}>
-  <Tab value="default">
-    <Button variant="primary" borderRadius="1.75rem">Default Radius</Button>
-  </Tab>
-  <Tab value="rounded">
-    <Button variant="primary" borderRadius="0.5rem">Rounded</Button>
-  </Tab>
-  <Tab value="square">
-    <Button variant="primary" borderRadius="0">Square</Button>
-  </Tab>
-  <Tab value="pill">
-    <Button variant="primary" borderRadius="9999px">Pill</Button>
-  </Tab>
+### Default
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <Button variant="moving-border"> Default Blue </Button>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+      <Button variant="moving-border"> Default Blue </Button>
+
+      ```
+
+    </Tab>
+
 </Tabs>
 
-```tsx
-<Button variant="primary" borderRadius="1.75rem">Default Radius</Button>
-<Button variant="primary" borderRadius="0.5rem">Rounded</Button>
-<Button variant="primary" borderRadius="0">Square</Button>
-<Button variant="primary" borderRadius="9999px">Pill</Button>
-```
+### Custom Color
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <Button variant="moving-border"  borderColor="#22c55e"> Custom Green </Button>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+      <Button variant="moving-border"  borderColor="#22c55e"> Custom Green </Button>
+
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Custom Speed
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <Button variant="moving-border" borderColor="#ef4444"duration={2000}>Faster Red</Button>
+
+    </Tab>
+
+    <Tab value="Code">
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+       <Button variant="moving-border" borderColor="#ef4444"duration={2000}>Faster Red</Button>
+
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Custom Gradient
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <Button variant="moving-border" borderClassName="bg-gradient-to-r from-red-500 to-blue-500">Gradient Border</Button>
+
+    </Tab>
+
+    <Tab value="Code">
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+       <Button variant="moving-border" borderClassName="bg-gradient-to-r from-red-500 to-blue-500">Gradient Border</Button>
+
+      ```
+
+    </Tab>
+
+</Tabs>
 
 ---
 
 ### Disabled State
 
-<div className="flex flex-col items-center justify-center mb-6 border border-zinc-800 rounded-lg py-5">
-  <div className="flex flex-wrap justify-center gap-4">
-    <Button disabled>Disabled Default</Button>
-    <Button variant="primary" disabled>Disabled Primary</Button>
-    <Button variant="moving-border" disabled>Disabled Moving</Button>
-  </div>
-</div>
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
 
-```tsx
-<Button disabled>Disabled Default</Button>
-<Button variant="primary" disabled>Disabled Primary</Button>
-<Button variant="moving-border" disabled>Disabled Moving</Button>
-```
+    <Tab value="Preview">
+
+       <div className="flex flex-wrap justify-center items-center gap-4">
+        <Button disabled>Disabled Default</Button>
+        <Button variant="primary" disabled>Disabled Primary</Button>
+        <Button variant="moving-border" disabled>Disabled Moving</Button>
+      </div>
+    </Tab>
+
+    <Tab value="Code">
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+        <Button disabled>Disabled Default</Button>
+        <Button variant="primary" disabled>Disabled Primary</Button>
+        <Button variant="moving-border" disabled>Disabled Moving</Button>
+
+      ```
+
+    </Tab>
+
+</Tabs>
 
 ---
 
-### Event Handling
+### Sizes
 
-```tsx
-import Button from "@/components/ui/snappy-button";
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
 
-export default function ButtonWithEvent() {
-  const handleClick = () => {
-    alert("Button clicked!");
-  };
+    <Tab value="Preview">
 
-  return (
-    <Button onClick={handleClick} variant="primary">
-      Click Me
-    </Button>
-  );
-}
-```
+
+       <div className="flex flex-wrap justify-center items-center gap-4">
+        <Button size="sm">Small</Button>
+        <Button size="default">Default</Button>
+        <Button size="lg">Large</Button>
+        <Button size="xl">Extra Large</Button>
+      </div>
+
+    </Tab>
+
+    <Tab value="Code">
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+        <Button size="sm">Small Button</Button>
+        <Button size="default">Default Button</Button>
+        <Button size="lg">Large Button</Button>
+        <Button size="xl">Extra Large Button</Button>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+---
+
+### Custom Border Radius
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+
+       <div className="flex flex-wrap justify-center items-center gap-4">
+          <Button variant="primary" borderRadius="1.75rem">Default Radius</Button>
+          <Button variant="primary" borderRadius="0.5rem">Rounded</Button>
+          <Button variant="primary" borderRadius="0">Square</Button>
+          <Button variant="primary" borderRadius="9999px">Pill</Button>
+      </div>
+    </Tab>
+
+    <Tab value="Code">
+      
+      ```tsx
+      import Button from "@/components/ui/snappy-button";
+
+          <Button variant="primary" borderRadius="1.75rem">Default Radius</Button>
+          <Button variant="primary" borderRadius="0.5rem">Rounded</Button>
+          <Button variant="primary" borderRadius="0">Square</Button>
+          <Button variant="primary" borderRadius="9999px">Pill</Button>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+---
 
 ## Installation
 

--- a/apps/snappyui/content/docs/components/snappycard.mdx
+++ b/apps/snappyui/content/docs/components/snappycard.mdx
@@ -3,51 +3,74 @@ title: Card
 description: A versatile card component for modern web applications
 ---
 
-
 import Card from "@/components/ui/snappy-card";
-
-
-
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 ---
 
-
 ## Basic Usage
 
-<div className="flex flex-col items-center justify-center mb-6 border-1 border-zinc-800 rounded-lg py-5">
-  <Card
-    title="Image Card"
-    variant="dark"
-  >
-    <img src="https://picsum.photos/300/200" alt="Random Image" className="rounded-lg"/>
-    <p>Random image from Lorem Picsum</p>
-  </Card>
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
 
-</div>
+    <Tab value="Preview">
 
-<Tabs items={["dark", "default", "primary", "success", "warning", "delete"]}>
-  <Tab value="dark">
-    <Card title="Default Card" variant="dark" className="text-gray-500">
+      <div className="flex flex-col items-center justify-center mb-6 border-1 border-zinc-800 rounded-lg py-5">
+        <Card title="Image Card" variant="dark">
+          <img src="https://picsum.photos/300/200" alt="Random Image" className="rounded-lg"/>
+          <p>Random image from Lorem Picsum</p>
+        </Card>
+      </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Card from "@/components/ui/snappy-card";
+
+      <div className="flex flex-col items-center justify-center mb-6 border-1 border-zinc-800 rounded-lg py-5">
+        <Card title="Image Card" variant="dark">
+          <img src="https://picsum.photos/300/200" alt="Random Image" className="rounded-lg"/>
+          <p>Random image from Lorem Picsum</p>
+        </Card>
+      </div>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+---
+
+## Variations
+
+### Default
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <Card title="Default Card" variant="default" className="text-gray-500">
       Basic card example with title and content.
     </Card>
-    ---
-    ```tsx 
-      <Card
-        title="Simple Card"
-        variant="dark"
-        className="text-gray-500"
-      >
-        Basic card example with title and content.
-      </Card>
-    ``` 
-  </Tab>
-  <Tab value="default">
-    <Card title="Default Card" variant="default" className="text-gray-500">
-      Basic card example with title and content.
-    </Card>
-    ---
-    ```tsx 
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Card from "@/components/ui/snappy-card";
+
       <Card
         title="Simple Card"
         variant="default"
@@ -55,14 +78,69 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
       >
         Basic card example with title and content.
       </Card>
-    ``` 
-  </Tab>
-  <Tab value="primary">
-   <Card title="Primary Card" variant="primary" className="text-gray-500">
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Dark
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <Card title="Dark Card" variant="dark" className="text-gray-500">
       Basic card example with title and content.
     </Card>
-    ---
-    ```tsx 
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Card from "@/components/ui/snappy-card";
+
+      <Card
+        title="Simple Card"
+        variant="dark"
+        className="text-gray-500"
+      >
+        Basic card example with title and content.
+      </Card>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Primary
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <Card title="Primary Card" variant="primary" className="text-gray-500">
+      Basic card example with title and content.
+    </Card>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Card from "@/components/ui/snappy-card";
+
       <Card
         title="Simple Card"
         variant="primary"
@@ -70,14 +148,34 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
       >
         Basic card example with title and content.
       </Card>
-    ```
-  </Tab>
-  <Tab value="success">
-    <Card title="Success Card" variant="success" className="text-gray-500">
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Success
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <Card title="Success Card" variant="success" className="text-gray-500">
       Basic card example with title and content.
     </Card>
-    ---
-    ```tsx 
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Card from "@/components/ui/snappy-card";
+
       <Card
         title="Simple Card"
         variant="success"
@@ -85,38 +183,72 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
       >
         Basic card example with title and content.
       </Card>
-    ```
-  </Tab>
-  <Tab value="warning">
-    <Card title="Warning Card" variant="warning" className="text-gray-500">
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Warning
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+     <Card title="Warning Card" variant="warning" className="text-gray-500">
       Basic card example with title and content.
     </Card>
-    ---
-    ```tsx 
-      <Card
-        title="Simple Card"
-        variant="warning"
-        className="text-gray-500"
-      >
-        Basic card example with title and content.
-      </Card>
-    ```
-  </Tab>
-  <Tab value="delete">
-    <Card title="Delete Card" variant="delete" className="text-gray-500">
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Card from "@/components/ui/snappy-card";
+
+      <Card title="Warning Card" variant="warning" className="text-gray-500">
       Basic card example with title and content.
     </Card>
-    ---
-    ```tsx 
-      <Card
-        title="Simple Card"
-        variant="delete"
-        className="text-gray-500"
-      >
-        Basic card example with title and content.
-      </Card>
-    ```
-  </Tab>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Delete
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <Card title="Delete Card" variant="delete" className="text-gray-500">
+      Basic card example with title and content.
+    </Card>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Card from "@/components/ui/snappy-card";
+
+       <Card title="Delete Card" variant="delete" className="text-gray-500">
+      Basic card example with title and content.
+    </Card>
+      ```
+
+    </Tab>
+
 </Tabs>
 
 ---
@@ -144,25 +276,6 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
     ```
   </Tab>
 </Tabs>
----
-
-## Code Example
-
-```tsx
-import Card from "@/components/ui/snappy-card";
-
-<div className="flex flex-col items-center justify-center mb-6">
-  <Card
-    title="Simple Card"
-    variant="primary"
-    image="https://media.istockphoto.com/id/517188688/photo/mountain-landscape.jpg?s=612x612&w=0&k=20&c=A63koPKaCyIwQWOTFBRWXj_PwCrR4cEoOw2S9Q7yVl8="
-    className="text-gray-500"
-  >
-    Basic card example with title and content.
-  </Card>
-</div>
-```
-
 ---
 
 ## Props

--- a/apps/snappyui/content/docs/components/snappycarousel.mdx
+++ b/apps/snappyui/content/docs/components/snappycarousel.mdx
@@ -5,25 +5,57 @@ description: Carousel is a component that allows you to create a carousel of ite
 
 import AnimatedCarousel from '@/components/ui/snappy-carousel';
 import carouselItems from '@/lib/data'
-
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 ---
-### Demo
 
+## Variations
 
-        <div className=" flex flex-col lg:flex-row gap-6 items-center justify-center w-full overflow-hidden border-1 border-gray-800 rounded-lg min-h-[500px] p-4">
-            <div className="w-full h-64 flex flex-col items-center justify-center">
-            <h1 className="text-2xl w-64 font-bold mb-6 text-center">Horizontal Carousel</h1>
-            <AnimatedCarousel
-                items={carouselItems}
-                variant="horizontal"
-                className="rounded-lg shadow-lg w-full h-full"
-            />
-            </div>
+### Horizontal Carousel
 
-            <div className="w-full h-64 flex flex-col items-center justify-center">
-            <h1 className="text-2xl font-bold mb-6 text-center">Vertical Carousel</h1>
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+     <div className="w-full h-64 flex flex-col items-center justify-center">
+        <AnimatedCarousel items={carouselItems} variant="horizontal" className="rounded-lg shadow-lg w-full h-full"/>
+    </div>
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+    import AnimatedCarousel from '@/components/ui/snappy-carousel';
+    import carouselItems from '@/lib/data'
+
+      <div className="w-full h-64 flex flex-col items-center justify-center">
+        <AnimatedCarousel items={carouselItems} variant="horizontal" className="rounded-lg shadow-lg w-full h-full"/>
+    </div>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+---
+
+### Vertical Carousel
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+     <div className="w-full h-64 flex flex-col items-center justify-center">
             <AnimatedCarousel
                 items={carouselItems}
                 variant="vertical"
@@ -31,8 +63,27 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
                 className="rounded-lg shadow-lg w-full h-full"
             />
             </div>
-        </div>
+    </Tab>
 
+    <Tab value="Code">
+
+      ```tsx
+    import AnimatedCarousel from '@/components/ui/snappy-carousel';
+    import carouselItems from '@/lib/data'
+
+      <div className="w-full h-64 flex flex-col items-center justify-center">
+            <AnimatedCarousel
+                items={carouselItems}
+                variant="vertical"
+                autoPlay={true}
+                className="rounded-lg shadow-lg w-full h-full"
+            />
+            </div>
+      ```
+
+    </Tab>
+
+</Tabs>
 
 ---
 
@@ -61,16 +112,7 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
   </Tab>
 </Tabs>
 
-
-### code example
-
-```tsx  
-    <AnimatedCarousel
-        items={carouselItems}
-        variant="horizontal"
-        className="rounded-lg shadow-lg w-full h-full"
-    />
-```
+---
 
 ## items array example
 

--- a/apps/snappyui/content/docs/components/snappycheck.mdx
+++ b/apps/snappyui/content/docs/components/snappycheck.mdx
@@ -24,31 +24,298 @@ export default function Example() {
 }
 ```
 
-## Animation Variants
+## Variations
 
 The component comes with 10 unique animation variants to enhance user experience.
 
-<div className="flex flex-wrap gap-6 my-8 border-1 border-zinc-800 rounded-lg py-5 px-5 justify-center">
-  {[
-    { label: "bounce", variant: "bounce" },
-    { label: "fade", variant: "fade" },
-    { label: "slide", variant: "slide" },
-    { label: "pulse", variant: "pulse" },
-    { label: "flip", variant: "flip" },
-    { label: "scale", variant: "scale" },
-    { label: "rotate", variant: "rotate" },
-    { label: "jello", variant: "jello" },
-    { label: "sweep", variant: "sweep" },
-    { label: "wave", variant: "wave" },
-  ].map(({ label }) => (
-    <div
-      key={label}
-      className="flex flex-col items-center gap-2 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg"
-    >
-      <Check label={label} variant={label} />
+### Bounce
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-center">
+      <Check label="Bounce" variant="bounce" />
+      </div>
+
+    </Tab>
+
+    <Tab value="Code">
+      ```tsx
+      import Check from "@/components/ui/snappy-checkbox";
+      <Check label="Bounce" variant="bounce" />
+      ```
+    </Tab>
+
+</Tabs>
+
+### Fade
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-center">
+       <Check label= "Fade" variant= "fade" />
+      </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Check from "@/components/ui/snappy-checkbox";
+
+      <Check label= "fade" variant= "fade" />
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Slide
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-center">
+       <Check label= "Slide" variant= "slide" />
     </div>
-  ))}
-</div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Check from "@/components/ui/snappy-checkbox";
+
+      <Check label= "Slide" variant= "slide" />
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Pulse
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-center">
+       <Check label= "Pulse" variant= "pulse" />
+    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Check from "@/components/ui/snappy-checkbox";
+
+       <Check label= "Pulse" variant= "pulse" />
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Flip
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-center">
+       <Check label= "Flip" variant= "flip" />
+    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Check from "@/components/ui/snappy-checkbox";
+
+     <Check label= "Flip" variant= "flip" />
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Scale
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-center">
+       <Check label= "Scale" variant= "scale" />
+    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Check from "@/components/ui/snappy-checkbox";
+
+     <Check label= "Scale" variant= "scale" />
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Rotate
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-center">
+       <Check label= "Rotate" variant= "rotate" />
+    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Check from "@/components/ui/snappy-checkbox";
+
+    <Check label= "Rotate" variant= "rotate" />
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Jello
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-center">
+       <Check label= "Jello" variant= "jello" />
+    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Check from "@/components/ui/snappy-checkbox";
+
+     <Check label= "Jello" variant= "jello" />
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Sweep
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+     <div className="flex justify-center">
+       <Check label= "Sweep" variant= "sweep" />
+    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Check from "@/components/ui/snappy-checkbox";
+
+      <Check label= "Sweep" variant= "sweep" />
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Wave
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-center">
+       <Check label= "Wave" variant= "wave" />
+    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Check from "@/components/ui/snappy-checkbox";
+
+     <Check label= "Wave" variant= "wave" />
+      ```
+
+    </Tab>
+
+</Tabs>
+
+---
 
 ## Installation
 
@@ -87,23 +354,6 @@ The component comes with 10 unique animation variants to enhance user experience
 | `className` | `string` | `''` | Additional CSS classes |
 | `id` | `string` | `undefined` | HTML ID attribute (auto-generated if not provided) |
 
-### CheckboxVariant Type
-
-```typescript
-type CheckboxVariant =
-  | 'bounce'
-  | 'fade'
-  | 'slide'
-  | 'pulse'
-  | 'flip'
-  | 'scale'
-  | 'rotate'
-  | 'jello'
-  | 'sweep'
-  | 'wave';
-```
-
-## Examples
 
 ### Form Integration
 

--- a/apps/snappyui/content/docs/components/snappycolorText.mdx
+++ b/apps/snappyui/content/docs/components/snappycolorText.mdx
@@ -3,7 +3,8 @@ title: ColorText
 description: A versatile ColorText component for modern web applications
 ---
 
-import { ColourfulText, OceanText, SunsetText, NeonText, MonochromeText, ForestText, GalaxyText, CyberpunkText, VintageText, CandyText, MatrixText, PastelText, SnappyText } from "@/components/ui/snappy-colorful-text";
+import { ColourfulText, OceanText, SunsetText, NeonText, MonochromeText, ForestText, GalaxyText, CyberpunkText,
+ VintageText, CandyText, MatrixText, PastelText, SnappyText } from "@/components/ui/snappy-colorful-text";
 
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
@@ -12,55 +13,403 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 ## Basic Usage
 
-<div className="flex flex-col items-center justify-center mb-6 border-1 gap-1 border-zinc-800 rounded-lg py-5">
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
 
-  <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
         Let's try <SnappyText text="SnappyUi" />  
-  </h6>
+      </h6>  
+    </Tab>
 
-</div>
+    <Tab value="Code">
 
-<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 p-6">
-  {[
-    { Component: SnappyText, name: "SnappyUi" },
-    { Component: PastelText, name: "SnappyUi" },
-    { Component: MatrixText, name: "SnappyUi" },
-    { Component: VintageText, name: "SnappyUi" },
-    { Component: CyberpunkText, name: "SnappyUi" },
-    { Component: GalaxyText, name: "SnappyUi" },
-    { Component: ForestText, name: "SnappyUi" },
-    { Component: MonochromeText, name: "SnappyUi" },
-    { Component: CandyText, name: "SnappyUi" },
-    { Component: NeonText, name: "SnappyUi" },
-    { Component: SunsetText, name: "SnappyUi" },
-    { Component: OceanText, name: "SnappyUi" },
-    { Component: ColourfulText, name: "SnappyUi" },
-  ].map(({ Component, name }, index) => (
-    <div
-      key={index}
-      className="flex items-center justify-center p-5 bg-white/10 backdrop-blur-xl rounded-xl shadow-md border border-white/20 hover:scale-105 hover:shadow-lg transition-all duration-300"
-    >
-      <p className="text-lg font-semibold text-gray-900 dark:text-gray-100 whitespace-nowrap">
-        Let's try <Component text={name} className="text-xl md:text-2xl font-bold" />
-      </p>
-    </div>
-  ))}
-</div>
+      ```tsx
+      import { SnappyText } from "@/components/ui/snappy-colorful-text";
 
 
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <SnappyText text="SnappyUi" />  
+      </h6>
+      
+      ```
 
+    </Tab>
+
+</Tabs>
 
 ---
 
-### Code Example
+## Variations
 
-```tsx
-import {ColourfulText,OceanText, SunsetText, NeonText, MonochromeText,ForestText,GalaxyText,CyberpunkText,VintageText,CandyText,MatrixText,PastelText,SnappyText} from "@/components/ui/snappy-colorful-text";
+### Colourful Text
 
-<div className="flex items-center justify-center">
-      Let's try <SnappyText text="SnappyUi" />
-</div>
-```
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <ColourfulText text="SnappyUi" />  
+        </h6>  
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { ColourfulText } from "@/components/ui/snappy-colorful-text";
+
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <ColourfulText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Ocean Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <OceanText text="SnappyUi" />  
+        </h6> 
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { OceanText } from "@/components/ui/snappy-colorful-text";
+
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <OceanText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Sunset Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <SunsetText text="SnappyUi" />  
+        </h6> 
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { SunsetText } from "@/components/ui/snappy-colorful-text";
+
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <SunsetText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Neon Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+     <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <NeonText text="SnappyUi" />  
+        </h6> 
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { NeonText } from "@/components/ui/snappy-colorful-text";
+
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <NeonText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Monochrome Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <MonochromeText text="SnappyUi" />  
+        </h6> 
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { MonochromeText } from "@/components/ui/snappy-colorful-text";
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <MonochromeText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Forest Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <ForestText text="SnappyUi" />  
+        </h6>  
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { ForestText } from "@/components/ui/snappy-colorful-text";
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <ForestText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Galaxy Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <GalaxyText text="SnappyUi" />  
+        </h6> 
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { GalaxyText } from "@/components/ui/snappy-colorful-text";
+
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <GalaxyText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Cyberpunk Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <CyberpunkText text="SnappyUi" />  
+        </h6> 
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { CyberpunkText } from "@/components/ui/snappy-colorful-text";
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <CyberpunkText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Vintage Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <VintageText text="SnappyUi" />  
+        </h6>  
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { VintageText } from "@/components/ui/snappy-colorful-text";
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <VintageText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Candy Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <CandyText text="SnappyUi" />  
+        </h6>  
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { CandyText } from "@/components/ui/snappy-colorful-text";
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <CandyText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Matrix Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <MatrixText text="SnappyUi" />  
+        </h6> 
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { MatrixText } from "@/components/ui/snappy-colorful-text";
+
+     <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <MatrixText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
+
+### Pastel Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <PastelText text="SnappyUi" />  
+        </h6> 
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { PastelText } from "@/components/ui/snappy-colorful-text";
+
+      <h6 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white relative z-2 font-sans">
+        Let's try <PastelText text="SnappyUi" />  
+        </h6>
+      
+      ```
+
+    </Tab>
+
+</Tabs>
 
 ---
 

--- a/apps/snappyui/content/docs/components/snappydropdown.mdx
+++ b/apps/snappyui/content/docs/components/snappydropdown.mdx
@@ -29,7 +29,16 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 ## Basic Usage
 
-<div className="flex flex-col items-center justify-center mb-6 border-1 border-zinc-800 rounded-lg py-5">
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+<div className="flex justify-center">
   <DropdownMenu>
       <DropdownMenuTrigger>User Menu</DropdownMenuTrigger>
       <DropdownMenuContent  className="w-56"  side="bottom">
@@ -106,17 +115,128 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
     
 </div>
 
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import{
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuCheckboxItem,
+    DropdownMenuRadioItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuShortcut,
+    DropdownMenuGroup,
+    DropdownMenuSub,
+    DropdownMenuSubTrigger,
+    DropdownMenuSubContent   
+    DropdownMenuRadioGroup,
+    DropdownMenuAction,
+    DropdownMenuHeader,
+    DropdownMenuFooter,
+    } from "@/components/ui/snappy-dropdown"
+   import { Settings, User, LogOut, Edit, Trash, Plus, FileText, Home, Bell,   MoreHorizontal, 
+   MoreVertical, ArrowRight } from "lucide-react"
+
+   <DropdownMenu>
+      <DropdownMenuTrigger>User Menu</DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuHeader 
+          title="John Doe" 
+          description="john.doe@example.com" 
+          icon={<User />} 
+        />
+        
+        <DropdownMenuGroup>
+          <DropdownMenuLabel badge="3">Account</DropdownMenuLabel>
+          <DropdownMenuItem icon={<User />}>
+            Profile
+            <DropdownMenuShortcut>⇧⌘P</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          
+          <DropdownMenuItem 
+            icon={<Settings />} 
+            description="Manage your account settings and preferences">
+            Settings
+          </DropdownMenuItem>
+          
+          <DropdownMenuItem icon={<Bell />} iconRight={<ArrowRight />}>
+            Notifications
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        
+        <DropdownMenuSeparator />
+        
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Content</DropdownMenuLabel>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger icon={<FileText />}>
+              Documents
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem icon={<Plus />}>New Document</DropdownMenuItem>
+              <DropdownMenuItem icon={<Edit />}>Edit</DropdownMenuItem>
+              <DropdownMenuItem icon={<Trash />}>Delete</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          
+          <DropdownMenuCheckboxItem 
+            description="Enable dark mode for better viewing at night"
+            checked={true}
+          >
+            Dark Mode
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuGroup>
+        
+        <DropdownMenuSeparator />
+        
+        <DropdownMenuRadioGroup value="public">
+          <DropdownMenuLabel>Visibility</DropdownMenuLabel>
+          <DropdownMenuRadioItem value="public" description="Anyone can see this document">
+            Public
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="private" description="Only you can access this document">
+            Private
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        
+        <DropdownMenuFooter>
+          <DropdownMenuAction variant="outline">
+            Help
+          </DropdownMenuAction>
+          <DropdownMenuAction variant="ghost">
+            <LogOut className="mr-2 h-4 w-4" />
+            Logout
+          </DropdownMenuAction>
+        </DropdownMenuFooter>
+      </DropdownMenuContent>
+    </DropdownMenu>
+      ```
+
+    </Tab>
+
+</Tabs>
+
+---
+
+## Variations
+
+### Default
+
 <Tabs
   items={[
-    "default",
-    "outline",
-    "ghost",
-    "contentSize",
-    "Complete Menu",
+    "Preview",
+    "Code",
   ]}
 >
-  <Tab value="default">
-    <div className="flex items-center justify-center">
+
+    <Tab value="Preview">
+
+      <div className="flex items-center justify-center">
         <DropdownMenu>
             <DropdownMenuTrigger>Default</DropdownMenuTrigger>
             <DropdownMenuContent side="bottom">
@@ -128,8 +248,39 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
         </DropdownMenu>
     </div>
   </Tab>
-  <Tab value="outline">
-    <div className="flex items-center justify-center">
+
+    <Tab value="Code">
+
+      ```tsx
+    import { DropdownMenu,DropdownMenuTrigger,DropdownMenuContent,DropdownMenuItem,DropdownMenuSeparator } from "@/components/ui/snappy-dropdown";
+
+    <DropdownMenu>
+        <DropdownMenuTrigger>Default</DropdownMenuTrigger>
+        <DropdownMenuContent>
+            <DropdownMenuItem>Profile</DropdownMenuItem>
+            <DropdownMenuItem>Settings </DropdownMenuItem>
+            <DropdownMenuSeparator/>
+            <DropdownMenuItem>Logout </DropdownMenuItem>
+        </DropdownMenuContent>
+    </DropdownMenu>
+    ```
+
+    </Tab>
+
+</Tabs>
+
+### Outline
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex items-center justify-center">
         <DropdownMenu>
             <DropdownMenuTrigger variant="outline">Outline</DropdownMenuTrigger>
             <DropdownMenuContent>
@@ -139,7 +290,65 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
         </DropdownMenu>
     </div>
   </Tab>
-  <Tab value="ghost">
+
+    <Tab value="Code">
+
+      ```tsx
+    import { DropdownMenu,DropdownMenuTrigger,DropdownMenuContent,DropdownMenuItem } from "@/components/ui/snappy-dropdown";
+
+    <DropdownMenu>
+        <DropdownMenuTrigger variant="outline">Outline</DropdownMenuTrigger>
+        <DropdownMenuContent>
+            <DropdownMenuItem>Profile</DropdownMenuItem>
+            <DropdownMenuItem>Settings </DropdownMenuItem>
+        </DropdownMenuContent>
+    </DropdownMenu>
+    ```
+
+    </Tab>
+
+</Tabs>
+
+### Ghost
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-between gap-4">
+        <DropdownMenu>
+            <DropdownMenuTrigger variant="ghost">
+                <MoreHorizontal/>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+                <DropdownMenuItem>Profile</DropdownMenuItem>
+                <DropdownMenuItem>Settings </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+
+        <DropdownMenu>
+            <DropdownMenuTrigger variant="ghost">
+                <MoreVertical/>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+                <DropdownMenuItem >Profile</DropdownMenuItem>
+                <DropdownMenuItem>Settings </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    </div>
+  </Tab>
+
+    <Tab value="Code">
+
+       ```tsx
+    import {DropdownMenu,DropdownMenuTrigger,DropdownMenuTrigger,DropdownMenuContent,DropdownMenuItem} from "@/components/ui/snappy-dropdown";
+    import { MoreHorizontal, MoreVertical } from "lucide-react"
+
     <div className="flex justify-between gap-4">
         <DropdownMenu>
             <DropdownMenuTrigger variant="ghost">
@@ -160,10 +369,25 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
                 <DropdownMenuItem>Settings </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>
-    </div>    
-  </Tab>
-  <Tab value="contentSize">
-    <div className="flex gap-4">
+    </div>   
+    ```
+
+    </Tab>
+
+</Tabs>
+
+### Content Size
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+       <div className="flex items-center justify-center gap-4">
         <DropdownMenu>
             <DropdownMenuTrigger>Default Size</DropdownMenuTrigger>
             <DropdownMenuContent>
@@ -189,8 +413,54 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
         </DropdownMenu>
     </div>
   </Tab>
-  <Tab value="Complete Menu">
-    <div className="flex justify-center items-center">
+
+    <Tab value="Code">
+
+       ```tsx
+    import {DropdownMenu,DropdownMenuTrigger,DropdownMenuTrigger,DropdownMenuContent,DropdownMenuItem} from "@/components/ui/snappy-dropdown";
+    <div className="flex gap-4">
+        <DropdownMenu>
+            <DropdownMenuTrigger>Default Size</DropdownMenuTrigger>
+            <DropdownMenuContent>
+            <DropdownMenuItem>Item 1</DropdownMenuItem>
+            <DropdownMenuItem>Item 2</DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+
+        <DropdownMenu>
+            <DropdownMenuTrigger>Large Size</DropdownMenuTrigger>
+            <DropdownMenuContent size="large">
+            <DropdownMenuItem>Item 1</DropdownMenuItem>
+            <DropdownMenuItem>Item 2</DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+
+        <DropdownMenu>
+            <DropdownMenuTrigger>Size</DropdownMenuTrigger>
+            <DropdownMenuContent size="compact">
+            <DropdownMenuItem>Item 1</DropdownMenuItem>
+            <DropdownMenuItem>Item 2</DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    </div>   
+    ```
+
+    </Tab>
+
+</Tabs>
+
+### Complete Menu
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex justify-center items-center">
     <DropdownMenu>
       <DropdownMenuTrigger>User Menu</DropdownMenuTrigger>
       <DropdownMenuContent className="w-56">
@@ -266,101 +536,10 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
     </DropdownMenu>
     </div>
   </Tab>
-</Tabs>
 
----
-### Installation
+    <Tab value="Code">
 
-<Tabs items={["pnpm", "npm", "bun", "yarn"]}>
-  <Tab value="pnpm">
-    ```bash
-    pnpm dlx shadcn@latest add http://snappyui.in/api/registry/dropdown
-    ```
-  </Tab>
-  <Tab value="npm">
-    ```bash
-    npx shadcn@latest add http://snappyui.in/api/registry/dropdown
-    ```
-  </Tab>
-  <Tab value="yarn">
-    ```bash
-    npx shadcn@latest add http://snappyui.in/api/registry/dropdown
-    ```
-  </Tab>
-  <Tab value="bun">
-    ```bash
-    bunx --bun shadcn@latest add http://snappyui.in/api/registry/dropdown
-    ```
-  </Tab>
-</Tabs>
-
----
-
-### Code Example
-
-<Tabs items={[ "default",
-    "outline",
-    "ghost",
-    "contentSize",
-    "Complete Menu"]}>
-  <Tab value="default">
-    ```tsx
-    import { DropdownMenu,DropdownMenuTrigger,DropdownMenuContent,DropdownMenuItem,DropdownMenuSeparator } from "@/components/ui/snappy-dropdown";
-
-    <DropdownMenu>
-        <DropdownMenuTrigger>Default</DropdownMenuTrigger>
-        <DropdownMenuContent>
-            <DropdownMenuItem>Profile</DropdownMenuItem>
-            <DropdownMenuItem>Settings </DropdownMenuItem>
-            <DropdownMenuSeparator/>
-            <DropdownMenuItem>Logout </DropdownMenuItem>
-        </DropdownMenuContent>
-    </DropdownMenu>
-    ```
-  </Tab>
-  <Tab value="outline">
-   ```tsx
-    import { DropdownMenu,DropdownMenuTrigger,DropdownMenuContent,DropdownMenuItem } from "@/components/ui/snappy-dropdown";
-
-    <DropdownMenu>
-        <DropdownMenuTrigger variant="outline">Outline</DropdownMenuTrigger>
-        <DropdownMenuContent>
-            <DropdownMenuItem>Profile</DropdownMenuItem>
-            <DropdownMenuItem>Settings </DropdownMenuItem>
-        </DropdownMenuContent>
-    </DropdownMenu>
-    ```  
-  </Tab>
-  <Tab value="ghost">
-    ```tsx
-    import {DropdownMenu,DropdownMenuTrigger,DropdownMenuTrigger,DropdownMenuContent,DropdownMenuItem} from "@/components/ui/snappy-dropdown";
-    import { MoreHorizontal, MoreVertical } from "lucide-react"
-
-    <div className="flex justify-between gap-4">
-        <DropdownMenu>
-            <DropdownMenuTrigger variant="ghost">
-                <MoreHorizontal/>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-                <DropdownMenuItem>Profile</DropdownMenuItem>
-                <DropdownMenuItem>Settings </DropdownMenuItem>
-            </DropdownMenuContent>
-        </DropdownMenu>
-
-        <DropdownMenu>
-            <DropdownMenuTrigger variant="ghost">
-                <MoreVertical/>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-                <DropdownMenuItem >Profile</DropdownMenuItem>
-                <DropdownMenuItem>Settings </DropdownMenuItem>
-            </DropdownMenuContent>
-        </DropdownMenu>
-    </div>   
-    ``` 
-  </Tab>
-  <Tab value="Complete Menu">
-   ```tsx
+       ```tsx
    import{
     DropdownMenu,
     DropdownMenuTrigger,
@@ -457,9 +636,36 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
       </DropdownMenuContent>
     </DropdownMenu>
       
-     ```  
+     ``` 
+
+    </Tab>
+
+</Tabs>
+
+---
+### Installation
+
+<Tabs items={["pnpm", "npm", "bun", "yarn"]}>
+  <Tab value="pnpm">
+    ```bash
+    pnpm dlx shadcn@latest add http://snappyui.in/api/registry/dropdown
+    ```
   </Tab>
-  
+  <Tab value="npm">
+    ```bash
+    npx shadcn@latest add http://snappyui.in/api/registry/dropdown
+    ```
+  </Tab>
+  <Tab value="yarn">
+    ```bash
+    npx shadcn@latest add http://snappyui.in/api/registry/dropdown
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```bash
+    bunx --bun shadcn@latest add http://snappyui.in/api/registry/dropdown
+    ```
+  </Tab>
 </Tabs>
 
 ---

--- a/apps/snappyui/content/docs/components/snappyloader.mdx
+++ b/apps/snappyui/content/docs/components/snappyloader.mdx
@@ -6,18 +6,40 @@ description: Loader component for Snappy UI
 
 import CircularLoader from '@/components/ui/snappy-loader'
 
-
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
-import { fromTheme } from 'tailwind-merge';
 
 
 
 ## Basic Usage
 
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
 
-<div className="flex flex-col items-center justify-center gap-7 mb-6 border-1 border-zinc-800 rounded-lg py-5">
-    <CircularLoader />
-</div>
+    <Tab value="Preview">
+
+      <div className="flex justify-center">
+        <CircularLoader />
+      </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+     import CircularLoader from '@/components/ui/snappy-loader'
+
+      <div className="flex justify-center">
+          <CircularLoader />
+      </div>
+      ```
+
+    </Tab>
+
+</Tabs>
 
 ---
 ### Installation
@@ -44,18 +66,6 @@ import { fromTheme } from 'tailwind-merge';
     ```
   </Tab>
 </Tabs>
----
-
-### Code Example
-
-```tsx
-import CircularLoader from '@/components/ui/snappy-loader'
-
-
-<div className="flex flex-col items-center justify-center gap-7 mb-6 border-1 border-zinc-800 rounded-lg py-5">
-    <CircularLoader />
-</div>
-```
 
 ---
 

--- a/apps/snappyui/content/docs/components/snappyskeleton.mdx
+++ b/apps/snappyui/content/docs/components/snappyskeleton.mdx
@@ -10,7 +10,16 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 ## Basic Usage
 
-<div className="flex flex-col items-center justify-center mb-6 border-1 gap-1 border-zinc-800 rounded-lg py-5">
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+     <div className="flex flex-col items-center justify-center mb-6 gap-1 rounded-lg py-5">
 
 <div className="flex flex-row gap-1">
 
@@ -24,40 +33,196 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
   <Skelton variant="rounded" width={200} height={30} />
 </div>
 
-<Tabs items={["Default", "Circular", "Rectangular", "Text", "No animation","Color" ]}>
-  <Tab value="Default">
-   <div className="flex items-center justify-center">
-      <Skelton  width={200} height={100}  />
-   </div>
-  </Tab>
-  <Tab value="Circular">
-    <div className="flex items-center justify-center">
-      <Skelton variant="circular" width={40} height={40}  />
-    </div>
-  </Tab>
-  <Tab value="Rectangular">
-    <div className="flex items-center justify-center">
-      <Skelton variant="rectangular" width={200} height={100}  />
-    </div>
-  </Tab>
-  <Tab value="Text">
-    <div className="flex items-center justify-center">
-      <Skelton variant="text" width={160} />
-    </div>  
-  </Tab>
-  <Tab value="No animation">
-     <div className="flex items-center justify-center">
-      <Skelton width={160} animation={false} />
-    </div>  
-  </Tab>
-  <Tab value="Color">
-     <div className="flex items-center justify-center">
-       <Skelton variant="rounded" width={200} height={100} className="bg-gray-800"  />
-    </div>  
-  </Tab>
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import Skelton from "@/components/ui/snappy-skeleton";
+
+      <div className="flex flex-col items-center justify-center mb-6 gap-1 rounded-lg py-5">
+
+<div className="flex flex-row gap-1">
+
+  <Skelton variant="circular" width={40} height={40} animation="pulse" />
+
+  <div className="flex flex-col gap-1">
+    <Skelton variant="text" width={160} />
+    <Skelton variant="text" width={160} />
+  </div>
+</div>
+  <Skelton variant="rounded" width={200} height={30} />
+</div>
+      ```
+
+    </Tab>
+
 </Tabs>
 
 ---
+
+## Variations
+
+### Default
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+  <Tab value="Preview">
+
+     <div className="flex items-center justify-center">
+      <Skelton  width={200} height={100}  />
+    </div>
+  </Tab>
+<Tab value="Code">
+
+     ```tsx
+     import Skelton from "@/components/ui/snappy-skeleton";
+      <div className="flex items-center justify-center">
+      <Skelton  width={200} height={100}  />
+      </div>
+     ```
+
+    </Tab>
+
+</Tabs>
+
+### Circular
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+  <Tab value="Preview">
+
+     <div className="flex items-center justify-center">
+      <Skelton variant="circular" width={40} height={40}  />
+    </div>
+  </Tab>
+<Tab value="Code">
+
+     ```tsx
+     import Skelton from "@/components/ui/snappy-skeleton";
+      <div className="flex items-center justify-center">
+      <Skelton variant="circular" width={40} height={40}  />
+    </div>
+     ```
+    </Tab>
+</Tabs>
+
+### Rectangular
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+  <Tab value="Preview">
+
+     <div className="flex items-center justify-center">
+      <Skelton variant="rectangular" width={200} height={100}  />
+    </div>
+  </Tab>
+<Tab value="Code">
+
+     ```tsx
+     import Skelton from "@/components/ui/snappy-skeleton";
+      <div className="flex items-center justify-center">
+      <Skelton variant="rectangular" width={200} height={100}  />
+    </div>
+     ```
+    </Tab>
+</Tabs>
+
+### Text
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+  <Tab value="Preview">
+
+     <div className="flex items-center justify-center">
+      <Skelton variant="text" width={160} />
+    </div>
+  </Tab>
+<Tab value="Code">
+
+     ```tsx
+     import Skelton from "@/components/ui/snappy-skeleton";
+      <div className="flex items-center justify-center">
+      <Skelton variant="text" width={160} />
+    </div>
+     ```
+    </Tab>
+</Tabs>
+
+### No Animation
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+  <Tab value="Preview">
+
+     <div className="flex items-center justify-center">
+      <Skelton width={160} animation={false} />
+    </div>
+  </Tab>
+<Tab value="Code">
+
+     ```tsx
+     import Skelton from "@/components/ui/snappy-skeleton";
+      <div className="flex items-center justify-center">
+      <Skelton width={160} animation={false} />
+    </div>
+     ```
+    </Tab>
+</Tabs>
+
+### Color
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+  <Tab value="Preview">
+
+     <div className="flex items-center justify-center">
+       <Skelton variant="rounded" width={200} height={100} className="bg-gray-800"  />
+    </div> 
+  </Tab>
+<Tab value="Code">
+
+     ```tsx
+     import Skelton from "@/components/ui/snappy-skeleton";
+      <div className="flex items-center justify-center">
+       <Skelton variant="rounded" width={200} height={100} className="bg-gray-800"  />
+    </div> 
+     ```
+    </Tab>
+</Tabs>
+
+---
+
 ### Installation
 
 <Tabs items={["pnpm", "npm", "bun", "yarn"]}>
@@ -82,18 +247,6 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
     ```
   </Tab>
 </Tabs>
----
-
-### Code Example
-
-```tsx
-import Skelton from "@/components/ui/snappy-skeleton";
-
-<div className="flex items-center justify-center">
-      <Skelton variant="rectangular" width={200} height={100}  />
-</div>
-```
-
 ---
 
 ## Props

--- a/apps/snappyui/content/docs/components/snappytoggle.mdx
+++ b/apps/snappyui/content/docs/components/snappytoggle.mdx
@@ -6,146 +6,175 @@ description: A versatile toggle switch component with multiple variants for mode
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import { ToggleExample, ToggleSizesExample, ToggleWithLabelsExample, ToggleDisabledExample } from "@/components/toggle-demo";
 
-# Toggle Component
-
-An interactive toggle switch component for indicating on/off states with multiple design variants.
-
 ## Basic Usage
 
 The toggle component allows users to switch between two states. By default, it uses the "simple" variant.
 
-<div className="flex items-center justify-start p-4 mb-6 border border-gray-200 rounded-md dark:border-gray-800">
-  <ToggleExample />
-</div>
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
 
-```tsx
-import { Toggle } from "@/components/ui/snappy-toggle";
-
-export function MyComponent() {
-  const [checked, setChecked] = useState(false);
-  
-  return (
-    <Toggle 
-      checked={checked}
-      onChange={setChecked}
-    />
-  );
-}
-```
-
-## Variants
-
-The toggle component comes with multiple design variants to fit different UI styles.
-
-<Tabs items={["simple", "dark", "primary", "minimal", "circular", "indicator", "elegant", "pill", "modern", "labeled", "themed"]}>
-  <Tab value="simple">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
       <ToggleExample variant="simple" />
-    </div>
-    
+
+    </Tab>
+
+    <Tab value="Code">
+
     ```tsx
+    import type { ToggleVariant } from "@/components/ui/snappy-toggle";
+
     <Toggle 
       variant="simple"
       checked={checked}
       onChange={setChecked}
     />
     ```
-  </Tab>
+    </Tab>
+</Tabs>
 
-  <Tab value="dark">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
-      <ToggleExample variant="dark" />
-    </div>
-    
-    ```tsx
-    <Toggle 
-      variant="dark"
-      checked={checked}
-      onChange={setChecked}
-    />
-    ```
-  </Tab>
+---
 
-  <Tab value="primary">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
+## Variants
+
+The toggle component comes with multiple design variants to fit different UI styles.
+
+### Primary
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
+
       <ToggleExample variant="primary" />
-    </div>
-    
+
+    </Tab>
+
+    <Tab value="Code">
+
     ```tsx
+    import type { ToggleVariant } from "@/components/ui/snappy-toggle";
+
     <Toggle 
       variant="primary"
       checked={checked}
       onChange={setChecked}
     />
     ```
-  </Tab>
+    </Tab>
+</Tabs>
 
-  <Tab value="minimal">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
+### Minimal
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
+
       <ToggleExample variant="minimal" />
-    </div>
-    
+
+    </Tab>
+
+    <Tab value="Code">
+
     ```tsx
+    import type { ToggleVariant } from "@/components/ui/snappy-toggle";
     <Toggle 
       variant="minimal"
       checked={checked}
       onChange={setChecked}
     />
     ```
-  </Tab>
-  
-  <Tab value="circular">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
+    </Tab>
+</Tabs>
+
+### Circular
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
+
       <ToggleExample variant="circular" />
-    </div>
-    
+
+    </Tab>
+
+    <Tab value="Code">
+
     ```tsx
+    import type { ToggleVariant } from "@/components/ui/snappy-toggle";
     <Toggle 
       variant="circular"
       checked={checked}
       onChange={setChecked}
     />
     ```
-  </Tab>
+    </Tab>
+</Tabs>
 
-  <Tab value="indicator">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
+### Indicator
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
+
       <ToggleExample variant="indicator" />
-    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
     
     ```tsx
+    import type { ToggleVariant } from "@/components/ui/snappy-toggle";
     <Toggle 
       variant="indicator"
       checked={checked}
       onChange={setChecked}
     />
     ```
-  </Tab>
+    </Tab>
+</Tabs>
 
-  <Tab value="elegant">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
-      <ToggleExample variant="elegant" />
-    </div>
-    
-    ```tsx
-    <Toggle 
-      variant="elegant"
-      checked={checked}
-      onChange={setChecked}
-    />
-    ```
-  </Tab>
+### Pill
 
-  <Tab value="pill">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
+
       <ToggleExample 
         variant="pill"
         onLabel="Active"
         offLabel="Inactive"
       />
-    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
     
-    ```tsx
+   ```tsx
+   import type { ToggleVariant } from "@/components/ui/snappy-toggle";
     <Toggle 
       variant="pill"
       onLabel="Active"
@@ -154,32 +183,60 @@ The toggle component comes with multiple design variants to fit different UI sty
       onChange={setChecked}
     />
     ```
-  </Tab>
+    </Tab>
+</Tabs>
 
-  <Tab value="modern">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
+### Modern
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
+
       <ToggleExample variant="modern" />
-    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
     
-    ```tsx
+   ```tsx
+   import type { ToggleVariant } from "@/components/ui/snappy-toggle";
     <Toggle 
       variant="modern"
       checked={checked}
       onChange={setChecked}
     />
     ```
-  </Tab>
+    </Tab>
+</Tabs>
 
-  <Tab value="labeled">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
+### Labeled
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
+
       <ToggleExample 
         variant="labeled"
         onLabel="ON" 
         offLabel="OFF"
       />
-    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
     
-    ```tsx
+   ```tsx
+   import type { ToggleVariant } from "@/components/ui/snappy-toggle";
     <Toggle 
       variant="labeled"
       onLabel="ON"
@@ -188,18 +245,32 @@ The toggle component comes with multiple design variants to fit different UI sty
       onChange={setChecked}
     />
     ```
-  </Tab>
+    </Tab>
+</Tabs>
 
-  <Tab value="themed">
-    <div className="p-4 border border-gray-200 rounded-md dark:border-gray-800">
+### Themed
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
+
       <ToggleExample 
         variant="themed"
         onLabel="Dark" 
         offLabel="Light"
       />
-    </div>
+
+    </Tab>
+
+    <Tab value="Code">
+
     
     ```tsx
+    import type { ToggleVariant } from "@/components/ui/snappy-toggle";
     <Toggle 
       variant="themed"
       onLabel="Dark"
@@ -208,18 +279,31 @@ The toggle component comes with multiple design variants to fit different UI sty
       onChange={setChecked}
     />
     ```
-  </Tab>
+    </Tab>
 </Tabs>
+
+---
 
 ## Sizes
 
 The toggle component supports three sizes: small, default, and large.
 
-<div className="p-4 mb-6 border border-gray-200 rounded-md dark:border-gray-800">
-  <ToggleSizesExample />
-</div>
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
 
-```tsx
+    <Tab value="Preview">
+
+      <ToggleSizesExample />
+
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
 // Small size
 <Toggle size="sm" checked={checked} onChange={setChecked} />
 
@@ -230,15 +314,30 @@ The toggle component supports three sizes: small, default, and large.
 <Toggle size="lg" checked={checked} onChange={setChecked} />
 ```
 
+    </Tab>
+
+</Tabs>
+
 ## With Labels
 
 Some toggle variants support labels for on and off states.
 
-<div className="p-4 mb-6 border border-gray-200 rounded-md dark:border-gray-800">
-  <ToggleWithLabelsExample />
-</div>
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
 
-```tsx
+      <ToggleWithLabelsExample />
+
+    </Tab>
+
+    <Tab value="Code">
+
+    
+    ```tsx
 // Labeled variant
 <Toggle 
   variant="labeled"
@@ -266,16 +365,29 @@ Some toggle variants support labels for on and off states.
   onChange={setChecked}
 />
 ```
+    </Tab>
+</Tabs>
 
 ## Disabled State
 
 Toggles can be disabled to prevent user interaction.
 
-<div className="p-4 mb-6 border border-gray-200 rounded-md dark:border-gray-800">
-  <ToggleDisabledExample />
-</div>
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+    <Tab value="Preview">
 
-```tsx
+      <ToggleDisabledExample />
+
+    </Tab>
+
+    <Tab value="Code">
+
+    
+    ```tsx
 // Disabled in the "on" state
 <Toggle 
   disabled
@@ -290,8 +402,8 @@ Toggles can be disabled to prevent user interaction.
   onChange={setChecked}
 />
 ```
-
-## API Reference
+    </Tab>
+</Tabs>
 
 ### Props
 

--- a/apps/snappyui/content/docs/components/snappytooltip.mdx
+++ b/apps/snappyui/content/docs/components/snappytooltip.mdx
@@ -14,26 +14,16 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 ## Basic Usage
 
-<div className="flex flex-col items-center justify-center mb-6 border-1 gap-1 border-zinc-800 rounded-lg py-5">
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
 
-  <TooltipProvider>
-  <Tooltip>
-    <TooltipTrigger>Warning info</TooltipTrigger>
-    <TooltipContent 
-      variant="default" 
-      size="md" 
-      hasArrow={true}
-       >
-      Important notice!
-    </TooltipContent>
-  </Tooltip>
-</TooltipProvider>
+    <Tab value="Preview">
 
-</div>
-
-<Tabs items={["Default", "Info", "Warning",  "Error","Success" ]}>
-  <Tab value="Default">
-   <div className="flex items-center justify-center">
+      <div className="flex items-center justify-center">
       <TooltipProvider>
         <Tooltip>
             <TooltipTrigger>Hover me !</TooltipTrigger>
@@ -47,9 +37,45 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
         </Tooltip>
       </TooltipProvider>
    </div>
-  </Tab>
-  <Tab value="Info">
-    <div className="flex items-center justify-center">
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,} from "@/components/ui/snappy-tooltip"
+
+      <TooltipProvider>
+        <Tooltip>
+            <TooltipTrigger>Hover me !</TooltipTrigger>
+            <TooltipContent 
+            variant="default" 
+            size="md" 
+            hasArrow={true}
+            >
+            Important notice!
+            </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      ```
+    </Tab>
+</Tabs>
+
+---
+
+## Variations
+
+### Info
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex items-center justify-center">
       <TooltipProvider>
         <Tooltip>
             <TooltipTrigger className="border-1 border-blue-500 p-1 rounded-lg">Hover me !</TooltipTrigger>
@@ -63,9 +89,41 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
         </Tooltip>
       </TooltipProvider>
     </div>
-  </Tab>
-  <Tab value="Warning">
-    <div className="flex items-center justify-center">
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,} from "@/components/ui/snappy-tooltip"
+
+      <TooltipProvider>
+        <Tooltip>
+            <TooltipTrigger className="border-1 border-blue-500 p-1 rounded-lg">Hover me !</TooltipTrigger>
+            <TooltipContent 
+            variant="info" 
+            size="md" 
+            hasArrow={true}
+            >
+            Important notice!
+            </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      ```
+    </Tab>
+</Tabs>
+
+### Warning
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex items-center justify-center">
       <TooltipProvider>
         <Tooltip>
             <TooltipTrigger className="border-1 border-amber-500 p-1 rounded-lg">Hover me !</TooltipTrigger>
@@ -79,9 +137,41 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
         </Tooltip>
       </TooltipProvider>
     </div>
-  </Tab>
- <Tab value="Error">
-     <div className="flex items-center justify-center">
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,} from "@/components/ui/snappy-tooltip"
+
+      <TooltipProvider>
+        <Tooltip>
+            <TooltipTrigger className="border-1 border-amber-500 p-1 rounded-lg">Hover me !</TooltipTrigger>
+            <TooltipContent 
+            variant="warning" 
+            size="md" 
+            hasArrow={true}
+            >
+            Important notice!
+            </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      ```
+    </Tab>
+</Tabs>
+
+### Error
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex items-center justify-center">
       <TooltipProvider>
         <Tooltip>
             <TooltipTrigger className="border-1 border-red-500 p-1 rounded-lg">Hover me !</TooltipTrigger>
@@ -94,10 +184,42 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
             </TooltipContent>
         </Tooltip>
       </TooltipProvider>
-    </div>  
-  </Tab>
-  <Tab value="Success">
-     <div className="flex items-center justify-center">
+    </div>
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,} from "@/components/ui/snappy-tooltip"
+
+      <TooltipProvider>
+        <Tooltip>
+            <TooltipTrigger className="border-1 border-red-500 p-1 rounded-lg">Hover me !</TooltipTrigger>
+            <TooltipContent 
+            variant="error" 
+            size="md" 
+            hasArrow={true}
+            >
+            Important notice!
+            </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      ```
+    </Tab>
+</Tabs>
+
+### Success
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+>
+
+    <Tab value="Preview">
+
+      <div className="flex items-center justify-center">
        <TooltipProvider>
         <Tooltip>
             <TooltipTrigger className="border-1 border-green-500 p-1 rounded-lg">Hover me !</TooltipTrigger>
@@ -110,8 +232,28 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
             </TooltipContent>
         </Tooltip>
       </TooltipProvider>
-    </div>  
-  </Tab>
+    </div>
+    </Tab>
+
+    <Tab value="Code">
+
+      ```tsx
+      import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,} from "@/components/ui/snappy-tooltip"
+
+      <TooltipProvider>
+        <Tooltip>
+            <TooltipTrigger className="border-1 border-green-500 p-1 rounded-lg">Hover me !</TooltipTrigger>
+            <TooltipContent 
+            variant="success" 
+            size="md" 
+            hasArrow={true}
+            >
+            Important notice!
+            </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      ```
+    </Tab>
 </Tabs>
 
 ---
@@ -139,34 +281,6 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
     ```
   </Tab>
 </Tabs>
-
----
-
-## Code Example
-
-```tsx
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/snappy-tooltip"
-
-<div className="flex items-center justify-center">
-      <TooltipProvider>
-        <Tooltip>
-            <TooltipTrigger>Hover me !</TooltipTrigger>
-            <TooltipContent 
-            variant="default" 
-            size="md" 
-            hasArrow={true}
-            >
-            Important notice!
-            </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-</div>
-```
 
 ---
 

--- a/apps/snappyui/content/docs/sections/snappyfooter.mdx
+++ b/apps/snappyui/content/docs/sections/snappyfooter.mdx
@@ -6,108 +6,17 @@ description: A versatile footer component with multiple variants for modern web 
 import Footer from "@/components/ui/snappy-footer";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
-
-
 ## Basic Usage
 
-<div className="flex flex-col items-center justify-center mb-6 border-1 border-zinc-800 rounded-lg p-5 gap-5">
-  <Footer
-    variant="simple"
-    copyright="© 2025 SnappyUI. All rights reserved."
-    columns={[
-      {
-        title: "Products",
-        links: [
-          { label: "Features", href: "/features" },
-          { label: "Pricing", href: "/pricing" },
-        ],
-      },
-      {
-        title: "Resources",
-        links: [
-          { label: "Documentation", href: "/docs" },
-          { label: "Blog", href: "/blog" },
-        ],
-      },
-    ]}
-    socialLinks={[
-      { label: "Twitter", href: "https://twitter.com" },
-      { label: "GitHub", href: "https://github.com" },
-    ]}
-  />
-</div>
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+  >
+    <Tab value="Preview">
 
-## Variants
-
-<Tabs items={["simple", "detailed", "minimal", "centered", "modern", "classic", "elegant"]}>
-  <Tab value="simple">
-    <Footer
-      variant="simple"
-      copyright="© 2025 SnappyUI. All rights reserved."
-      columns={[
-        {
-          title: "Products",
-          links: [
-            { label: "Features", href: "/features" },
-            { label: "Pricing", href: "/pricing" },
-          ],
-        },
-        {
-          title: "Resources",
-          links: [
-            { label: "Documentation", href: "/docs" },
-            { label: "Blog", href: "/blog" },
-          ],
-        },
-      ]}
-      socialLinks={[
-        { label: "Twitter", href: "https://twitter.com" },
-        { label: "GitHub", href: "https://github.com" },
-      ]}
-    />
-  </Tab>
-
-  <Tab value="detailed">
-    <Footer
-      variant="detailed"
-      copyright="© 2025 SnappyUI. All rights reserved."
-      columns={[
-        {
-          title: "PRODUCTS",
-          links: [
-            { label: "Features", href: "/features" },
-            { label: "Pricing", href: "/pricing" },
-            { label: "Templates", href: "/templates" },
-          ],
-        },
-        {
-          title: "RESOURCES",
-          links: [
-            { label: "Documentation", href: "/docs" },
-            { label: "Blog", href: "/blog" },
-            { label: "Support", href: "/support" },
-          ],
-        },
-        {
-          title: "COMPANY",
-          links: [
-            { label: "About", href: "/about" },
-            { label: "Contact", href: "/contact" },
-            { label: "Careers", href: "/careers" },
-          ],
-        },
-      ]}
-      socialLinks={[
-        { label: "Twitter", href: "https://twitter.com" },
-        { label: "GitHub", href: "https://github.com" },
-        { label: "LinkedIn", href: "https://linkedin.com" },
-      ]}
-      bottomText="Making web development snappy since 2023"
-    />
-  </Tab>
-
-  <Tab value="minimal">
-    <Footer
+       <Footer
       variant="minimal"
       copyright="© 2025 SnappyUI"
       columns={[
@@ -124,10 +33,49 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
         { label: "GitHub", href: "https://github.com" },
       ]}
     />
-  </Tab>
 
-  <Tab value="centered">
-    <Footer
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Footer from "@/components/ui/snappy-footer";
+
+      <Footer
+      variant="minimal"
+      copyright="© 2025 SnappyUI"
+      columns={[
+        {
+          links: [
+            { label: "Terms", href: "/terms" },
+            { label: "Privacy", href: "/privacy" },
+            { label: "Cookies", href: "/cookies" },
+          ],
+        },
+      ]}
+      socialLinks={[
+        { label: "Twitter", href: "https://twitter.com" },
+        { label: "GitHub", href: "https://github.com" },
+      ]}
+    />
+      ```
+    </Tab>
+</Tabs>
+
+## Variants
+
+### Centered
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+  >
+    <Tab value="Preview">
+
+       <Footer
       variant="centered"
       copyright="© 2025 SnappyUI. All rights reserved."
       columns={[
@@ -148,112 +96,25 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
         { label: "YouTube", href: "https://youtube.com" },
       ]}
     />
-  </Tab>
 
-  {/* <Tab value="dark">
-    <Footer
-      variant="dark"
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Footer from "@/components/ui/snappy-footer";
+
+      <Footer
+      variant="centered"
       copyright="© 2025 SnappyUI. All rights reserved."
       columns={[
         {
-          title: "PRODUCTS",
-          links: [
-            { label: "Components", href: "/components" },
-            { label: "Templates", href: "/templates" },
-            { label: "Pricing", href: "/pricing" }, 
-          ],
-        },
-        {
-          title: "RESOURCES",
-          links: [
-            { label: "Documentation", href: "/docs" },
-            { label: "API Reference", href: "/api" },
-            { label: "Examples", href: "/examples" },
-          ],
-        },
-        {
-          title: "COMPANY",
-          links: [
-            { label: "About", href: "/about" },
-            { label: "Blog", href: "/blog" },
-            { label: "Careers", href: "/careers" },
-          ],
-        },
-      ]}
-      socialLinks={[
-        { label: "Twitter", href: "https://twitter.com" },
-        { label: "GitHub", href: "https://github.com" },
-        { label: "Discord", href: "https://discord.com" },
-      ]}
-      bottomText="Building modern UIs for the web"
-    />
-  </Tab> */}
-
-  <Tab value="modern">
-    <Footer
-      variant="modern"
-      copyright="© 2025 SnappyUI. All rights reserved."
-      columns={[
-        {
-          title: "Products",
           links: [
             { label: "Features", href: "/features" },
             { label: "Pricing", href: "/pricing" },
-            { label: "Templates", href: "/templates" },
-          ],
-        },
-        {
-          title: "Resources",
-          links: [
             { label: "Documentation", href: "/docs" },
-            { label: "API", href: "/api" },
-            { label: "Guides", href: "/guides" },
-          ],
-        },
-        {
-          title: "Company",
-          links: [
             { label: "About", href: "/about" },
-            { label: "Blog", href: "/blog" },
-            { label: "Careers", href: "/careers" },
-          ],
-        },
-      ]}
-      socialLinks={[
-        { label: "Twitter", href: "https://twitter.com" },
-        { label: "GitHub", href: "https://github.com" },
-        { label: "LinkedIn", href: "https://linkedin.com" },
-      ]}
-      bottomText="Creating modern user interfaces with style"
-    />
-  </Tab>
-
-  <Tab value="classic">
-    <Footer
-      variant="classic"
-      copyright="© 2025 SnappyUI. All rights reserved."
-      columns={[
-        {
-          title: "Services",
-          links: [
-            { label: "Web Design", href: "/web-design" },
-            { label: "Development", href: "/development" },
-            { label: "Consulting", href: "/consulting" },
-          ],
-        },
-        {
-          title: "Learn",
-          links: [
-            { label: "Tutorials", href: "/tutorials" },
-            { label: "Resources", href: "/resources" },
-            { label: "Blog", href: "/blog" },
-          ],
-        },
-        {
-          title: "About",
-          links: [
-            { label: "Our Story", href: "/story" },
-            { label: "Team", href: "/team" },
             { label: "Contact", href: "/contact" },
           ],
         },
@@ -262,13 +123,24 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
         { label: "Twitter", href: "https://twitter.com" },
         { label: "GitHub", href: "https://github.com" },
         { label: "LinkedIn", href: "https://linkedin.com" },
+        { label: "YouTube", href: "https://youtube.com" },
       ]}
-      bottomText="Crafting digital experiences since 2020"
     />
-  </Tab>
+      ```
+    </Tab>
+</Tabs>
 
-  <Tab value="elegant">
-    <Footer
+### Elegant
+
+<Tabs
+  items={[
+    "Preview",
+    "Code",
+  ]}
+  >
+    <Tab value="Preview">
+
+       <Footer
       variant="elegant"
       copyright="© 2025 SnappyUI. All rights reserved."
       columns={[
@@ -304,8 +176,56 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
       ]}
       bottomText="Elegant solutions for modern challenges"
     />
-  </Tab>
+
+    </Tab>
+
+    <Tab value="Code">
+
+      
+      ```tsx
+      import Footer from "@/components/ui/snappy-footer";
+
+      <Footer
+      variant="elegant"
+      copyright="© 2025 SnappyUI. All rights reserved."
+      columns={[
+        {
+          title: "Solutions",
+          links: [
+            { label: "Enterprise", href: "/enterprise" },
+            { label: "Startups", href: "/startups" },
+            { label: "Personal", href: "/personal" },
+          ],
+        },
+        {
+          title: "Resources",
+          links: [
+            { label: "Documentation", href: "/docs" },
+            { label: "Case Studies", href: "/case-studies" },
+            { label: "Whitepapers", href: "/whitepapers" },
+          ],
+        },
+        {
+          title: "Company",
+          links: [
+            { label: "About", href: "/about" },
+            { label: "Values", href: "/values" },
+            { label: "Contact", href: "/contact" },
+          ],
+        },
+      ]}
+      socialLinks={[
+        { label: "Twitter", href: "https://twitter.com" },
+        { label: "GitHub", href: "https://github.com" },
+        { label: "LinkedIn", href: "https://linkedin.com" },
+      ]}
+      bottomText="Elegant solutions for modern challenges"
+    />
+      ```
+    </Tab>
 </Tabs>
+
+---
 
 ## Installation
 
@@ -333,307 +253,7 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
   </Tab>
 </Tabs>
 
-## Code Example
-
-<Tabs items={["simple", "detailed", "minimal", "centered", "modern", "classic", "elegant"]}>
-  <Tab value="simple">
-```tsx
-import Footer from "@/components/ui/snappy-footer";
-
-<Footer 
-  variant="simple" 
-  copyright="© 2025 SnappyUI. All rights reserved." 
-  columns={[
-    { 
-      title: "Products", 
-      links: [
-        { label: "Features", href: "/features" }, 
-        { label: "Pricing", href: "/pricing" }
-      ] 
-    }, 
-    { 
-      title: "Resources", 
-      links: [
-        { label: "Documentation", href: "/docs" }, 
-        { label: "Blog", href: "/blog" }
-      ] 
-    }
-  ]} 
-  socialLinks={[
-    { label: "Twitter", href: "https://twitter.com" }, 
-    { label: "GitHub", href: "https://github.com" }
-  ]} 
-/>
-```
-  </Tab>
-
-  <Tab value="detailed">
-```tsx
-import Footer from "@/components/ui/snappy-footer";
-
-<Footer 
-  variant="detailed" 
-  copyright="© 2025 SnappyUI. All rights reserved." 
-  columns={[
-    { 
-      title: "PRODUCTS", 
-      links: [
-        { label: "Features", href: "/features" }, 
-        { label: "Pricing", href: "/pricing" }, 
-        { label: "Templates", href: "/templates" }
-      ] 
-    }, 
-    { 
-      title: "RESOURCES", 
-      links: [
-        { label: "Documentation", href: "/docs" }, 
-        { label: "Blog", href: "/blog" }, 
-        { label: "Support", href: "/support" }
-      ] 
-    }, 
-    { 
-      title: "COMPANY", 
-      links: [
-        { label: "About", href: "/about" }, 
-        { label: "Contact", href: "/contact" }, 
-        { label: "Careers", href: "/careers" }
-      ] 
-    }
-  ]} 
-  socialLinks={[
-    { label: "Twitter", href: "https://twitter.com" }, 
-    { label: "GitHub", href: "https://github.com" }, 
-    { label: "LinkedIn", href: "https://linkedin.com" }
-  ]} 
-  bottomText="Making web development snappy since 2023" 
-/>
-```
-  </Tab>
-
-  <Tab value="minimal">
-```tsx 
-import Footer from "@/components/ui/snappy-footer";
-
-<Footer 
-  variant="minimal" 
-  copyright="© 2025 SnappyUI" 
-  columns={[
-    { 
-      links: [
-        { label: "Terms", href: "/terms" }, 
-        { label: "Privacy", href: "/privacy" }, 
-        { label: "Cookies", href: "/cookies" }
-      ] 
-    }
-  ]} 
-  socialLinks={[
-    { label: "Twitter", href: "https://twitter.com" }, 
-    { label: "GitHub", href: "https://github.com" }
-  ]} 
-/>
-```
-  </Tab>
-
-  <Tab value="centered">
-```tsx 
-import Footer from "@/components/ui/snappy-footer";
-
-<Footer 
-  variant="centered" 
-  copyright="© 2025 SnappyUI. All rights reserved." 
-  columns={[
-    { 
-      links: [
-        { label: "Features", href: "/features" }, 
-        { label: "Pricing", href: "/pricing" }, 
-        { label: "Documentation", href: "/docs" }, 
-        { label: "About", href: "/about" }, 
-        { label: "Contact", href: "/contact" }
-      ] 
-    }
-  ]} 
-  socialLinks={[
-    { label: "Twitter", href: "https://twitter.com" }, 
-    { label: "GitHub", href: "https://github.com" }, 
-    { label: "LinkedIn", href: "https://linkedin.com" }, 
-    { label: "YouTube", href: "https://youtube.com" }
-  ]} 
-/>
-```
-  </Tab>
-
-  {/* <Tab value="dark">
-```tsx
-import Footer from "@/components/ui/snappy-footer";
-
-<Footer 
-  variant="dark" 
-  copyright="© 2025 SnappyUI. All rights reserved." 
-  columns={[
-    { 
-      title: "PRODUCTS", 
-      links: [
-        { label: "Components", href: "/components" }, 
-        { label: "Templates", href: "/templates" }, 
-        { label: "Pricing", href: "/pricing" }
-      ] 
-    }, 
-    { 
-      title: "RESOURCES", 
-      links: [
-        { label: "Documentation", href: "/docs" }, 
-        { label: "API Reference", href: "/api" }, 
-        { label: "Examples", href: "/examples" }
-      ] 
-    }, 
-    { 
-      title: "COMPANY", 
-      links: [
-        { label: "About", href: "/about" }, 
-        { label: "Blog", href: "/blog" }, 
-        { label: "Careers", href: "/careers" }
-      ] 
-    }
-  ]} 
-  socialLinks={[
-    { label: "Twitter", href: "https://twitter.com" }, 
-    { label: "GitHub", href: "https://github.com" }, 
-    { label: "Discord", href: "https://discord.com" }
-  ]} 
-  bottomText="Building modern UIs for the web" 
-/>
-```
-  </Tab> */}
-
-  <Tab value="modern">
-```tsx
-import Footer from "@/components/ui/snappy-footer";
-
-<Footer 
-  variant="modern" 
-  copyright="© 2025 SnappyUI. All rights reserved." 
-  columns={[
-    { 
-      title: "Products", 
-      links: [
-        { label: "Features", href: "/features" }, 
-        { label: "Pricing", href: "/pricing" }, 
-        { label: "Templates", href: "/templates" }
-      ] 
-    }, 
-    { 
-      title: "Resources", 
-      links: [
-        { label: "Documentation", href: "/docs" }, 
-        { label: "API", href: "/api" }, 
-        { label: "Guides", href: "/guides" }
-      ] 
-    }, 
-    { 
-      title: "Company", 
-      links: [
-        { label: "About", href: "/about" }, 
-        { label: "Blog", href: "/blog" }, 
-        { label: "Careers", href: "/careers" }
-      ] 
-    }
-  ]} 
-  socialLinks={[
-    { label: "Twitter", href: "https://twitter.com" }, 
-    { label: "GitHub", href: "https://github.com" }, 
-    { label: "LinkedIn", href: "https://linkedin.com" }
-  ]} 
-  bottomText="Creating modern user interfaces with style" 
-/>
-```
-  </Tab>
-
-  <Tab value="classic">
-```tsx
-import Footer from "@/components/ui/snappy-footer";
-
-<Footer 
-  variant="classic" 
-  copyright="© 2025 SnappyUI. All rights reserved." 
-  columns={[
-    { 
-      title: "Services", 
-      links: [
-        { label: "Web Design", href: "/web-design" }, 
-        { label: "Development", href: "/development" }, 
-        { label: "Consulting", href: "/consulting" }
-      ] 
-    }, 
-    { 
-      title: "Learn", 
-      links: [
-        { label: "Tutorials", href: "/tutorials" }, 
-        { label: "Resources", href: "/resources" }, 
-        { label: "Blog", href: "/blog" }
-      ] 
-    }, 
-    { 
-      title: "About", 
-      links: [
-        { label: "Our Story", href: "/story" }, 
-        { label: "Team", href: "/team" }, 
-        { label: "Contact", href: "/contact" }
-      ] 
-    }
-  ]} 
-  socialLinks={[
-    { label: "Twitter", href: "https://twitter.com" }, 
-    { label: "GitHub", href: "https://github.com" }, 
-    { label: "LinkedIn", href: "https://linkedin.com" }
-  ]} 
-  bottomText="Crafting digital experiences since 2020" 
-/>
-```
-  </Tab>
-  
-  <Tab value="elegant">
-```tsx
-import Footer from "@/components/ui/snappy-footer";
-
-<Footer 
-  variant="elegant" 
-  copyright="© 2025 SnappyUI. All rights reserved." 
-  columns={[
-    { 
-      title: "Solutions", 
-      links: [
-        { label: "Enterprise", href: "/enterprise" }, 
-        { label: "Startups", href: "/startups" }, 
-        { label: "Personal", href: "/personal" }
-      ] 
-    }, 
-    { 
-      title: "Resources", 
-      links: [
-        { label: "Documentation", href: "/docs" }, 
-        { label: "Case Studies", href: "/case-studies" }, 
-        { label: "Whitepapers", href: "/whitepapers" }
-      ] 
-    }, 
-    { 
-      title: "Company", 
-      links: [
-        { label: "About", href: "/about" }, 
-        { label: "Values", href: "/values" }, 
-        { label: "Contact", href: "/contact" }
-      ] 
-    }
-  ]} 
-  socialLinks={[
-    { label: "Twitter", href: "https://twitter.com" }, 
-    { label: "GitHub", href: "https://github.com" }, 
-    { label: "LinkedIn", href: "https://linkedin.com" }
-  ]} 
-  bottomText="Elegant solutions for modern challenges" 
-/>
-```
-  </Tab>
-</Tabs>
+---
 
 ## Props
 


### PR DESCRIPTION
- Updated SnappyLoader docs with Tabs for Preview and Code examples.
- Enhanced SnappySkeleton docs with Tabs for various skeleton types.
- Reorganized SnappyToggle docs for variant-specific Tabs.
- Improved SnappyTooltip docs with variation-based Tabs.
- Revamped SnappyFooter docs to use Tabs per footer variant.