### PR TITLE
Add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  snappyui:
+    build: .
+    ports:
+      - "3000:3000"
+    restart: always


### PR DESCRIPTION
This docker-compose.yml file streamlines management of the Snappyui application using Docker Compose. It builds the image, runs the container on port 3000, and ensures automatic restarts. Use `docker-compose up -d` for a straightforward, reproducible, and resilient deployment, with scalability options for future services.

The command `docker-compose up -d` is used to create and start all the services.
The command `docker-compose down --rmi all` is used to stop and remove resources.